### PR TITLE
feat: add house cusp calculations

### DIFF
--- a/astrocore/eph/swiss.py
+++ b/astrocore/eph/swiss.py
@@ -42,6 +42,12 @@ def houses(jd_ut: float, lat: float, lon: float):
         return swe.houses(jd_ut, lat, lon)
 
 
+def houses_ex(jd_ut: float, lat: float, lon: float, hsys: bytes):
+    """Thread-safe wrapper around ``swe.houses_ex`` allowing house system selection."""
+    with _swe_lock:
+        return swe.houses_ex(jd_ut, lat, lon, hsys)
+
+
 def get_ayanamsa(jd_ut: float) -> float:
     with _swe_lock:
         return swe.get_ayanamsa(jd_ut)

--- a/astrocore/houses.py
+++ b/astrocore/houses.py
@@ -1,0 +1,171 @@
+"""House calculations for astrocore."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal, Dict, List
+
+from .eph import swiss
+from .utils.angles import mod360
+
+
+@dataclass
+class HouseRequest:
+    jd_ut: float
+    geo_lat_deg: float
+    geo_lon_deg: float
+    ayanamsa: str = "Lahiri"
+    house_system: Literal["whole-sign", "sripati", "placidus"] = "whole-sign"
+    backend: Literal["auto", "swiss", "native"] = "auto"
+    options: Dict[str, object] = field(default_factory=dict)
+
+
+def to_sidereal(lon_trop_deg: float, ayanamsa_value_deg: float) -> float:
+    """Convert tropical longitude to sidereal."""
+    return mod360(lon_trop_deg - ayanamsa_value_deg)
+
+
+def compute_angles_native(jd_ut: float, lat: float, lon: float, epsilon_mode: str = "true-of-date") -> Dict[str, float]:
+    """Compute Ascendant, Midheaven and derived angles (tropical)."""
+    # Use Swiss Ephemeris for angular calculations. Houses system does not
+    # influence the angles for quadrant methods, therefore we can rely on
+    # Placidus here.
+    _, ascmc = swiss.houses_ex(jd_ut, lat, lon, b"P")
+    asc = ascmc[0]
+    mc = ascmc[1]
+    return {
+        "asc_deg": asc,
+        "mc_deg": mc,
+        "desc_deg": mod360(asc + 180.0),
+        "ic_deg": mod360(mc + 180.0),
+    }
+
+
+def compute_sripati_from_angles(asc: float, mc: float) -> List[float]:
+    """Compute Śrīpati (Porphyry) house cusps from Asc and MC (sidereal)."""
+    asc = mod360(asc)
+    mc = mod360(mc)
+    ic = mod360(mc + 180.0)
+    desc = mod360(asc + 180.0)
+    cusps = [0.0] * 12
+    cusps[0] = asc  # 1st house
+    cusps[3] = ic   # 4th house
+    cusps[6] = desc # 7th house
+    cusps[9] = mc   # 10th house
+
+    arc_mc_asc = (asc - mc) % 360.0
+    step1 = arc_mc_asc / 3.0
+    cusps[10] = mod360(mc + step1)        # 11th
+    cusps[11] = mod360(mc + 2 * step1)    # 12th
+    cusps[4] = mod360(cusps[10] + 180.0)  # 5th
+    cusps[5] = mod360(cusps[11] + 180.0)  # 6th
+
+    arc_asc_ic = (ic - asc) % 360.0
+    step2 = arc_asc_ic / 3.0
+    cusps[1] = mod360(asc + step2)        # 2nd
+    cusps[2] = mod360(asc + 2 * step2)    # 3rd
+    cusps[7] = mod360(cusps[1] + 180.0)   # 8th
+    cusps[8] = mod360(cusps[2] + 180.0)   # 9th
+
+    return [mod360(c) for c in cusps]
+
+
+def _borders_and_widths(cusps: List[float]) -> Dict[str, List[float]]:
+    borders: List[float] = []
+    widths: List[float] = []
+    for i in range(12):
+        c1 = cusps[i]
+        c2 = cusps[(i + 1) % 12]
+        width = (c2 - c1) % 360.0
+        widths.append(width)
+        borders.append(mod360(c1 + width / 2.0))
+    return {"borders": borders, "width": widths}
+
+
+def compute_houses(req: HouseRequest) -> Dict[str, object]:
+    """Compute house cusps and related data according to request."""
+    # Decide backend: sign-based systems don't require Swiss calls.
+    backend = req.backend
+    if backend == "auto":
+        backend = "native" if req.house_system in ("whole-sign", "sripati") else "swiss"
+
+    ayan_deg = swiss.get_ayanamsa(req.jd_ut)
+    epsilon_deg = swiss.ecl_nut(req.jd_ut)[0]
+    gst_hours = swiss.sidtime(req.jd_ut)
+    lst_hours = (gst_hours + req.geo_lon_deg / 15.0) % 24.0
+    ramc_deg = (lst_hours * 15.0) % 360.0
+
+    angles_trop = compute_angles_native(req.jd_ut, req.geo_lat_deg, req.geo_lon_deg)
+    angles = {
+        "asc_deg_sid": to_sidereal(angles_trop["asc_deg"], ayan_deg),
+        "mc_deg_sid": to_sidereal(angles_trop["mc_deg"], ayan_deg),
+    }
+    angles["desc_deg_sid"] = mod360(angles["asc_deg_sid"] + 180.0)
+    angles["ic_deg_sid"] = mod360(angles["mc_deg_sid"] + 180.0)
+
+    houses: Dict[str, object] = {}
+    options = req.options or {}
+    status = "ok"
+    notes = ""
+
+    if req.house_system == "whole-sign":
+        houses["type"] = "sign-based"
+        asc_sign_start = int(angles["asc_deg_sid"] // 30) * 30.0
+        borders = [mod360(asc_sign_start + i * 30.0) for i in range(12)]
+        houses["borders_deg_sid"] = borders
+        houses["madhya_deg_sid"] = [mod360(b + 15.0) for b in borders]
+        if options.get("return_width"):
+            houses["width_deg"] = [30.0] * 12
+    else:
+        houses["type"] = "cuspal"
+        if req.house_system == "sripati" or status == "fallback":
+            cusps = compute_sripati_from_angles(angles["asc_deg_sid"], angles["mc_deg_sid"])
+        else:  # placidus via Swiss
+            try:
+                cusps_trop, _ = swiss.houses_ex(req.jd_ut, req.geo_lat_deg, req.geo_lon_deg, b"P")
+                cusps = [to_sidereal(c, ayan_deg) for c in cusps_trop]
+            except Exception:
+                status = "fallback"
+                notes = "fallback to sripati because placidus undefined at latitude"
+                cusps = compute_sripati_from_angles(angles["asc_deg_sid"], angles["mc_deg_sid"])
+        houses["cusps_deg_sid"] = cusps
+        if options.get("return_borders") or options.get("return_width"):
+            bw = _borders_and_widths(cusps)
+            if options.get("return_borders"):
+                houses["borders_deg_sid"] = bw["borders"]
+            if options.get("return_width"):
+                houses["width_deg"] = bw["width"]
+
+    meta = {
+        "house_system": req.house_system,
+        "backend": backend,
+        "ayanamsa": {"name": req.ayanamsa, "value_deg": ayan_deg},
+        "lst_deg": lst_hours * 15.0,
+        "epsilon_deg": epsilon_deg,
+        "ramc_deg": ramc_deg,
+        "status": status,
+    }
+    if notes:
+        meta["notes"] = notes
+
+    classification = {
+        "kendra": [1, 4, 7, 10],
+        "trikona": [1, 5, 9],
+        "upachaya": [3, 6, 10, 11],
+        "dusthana": [6, 8, 12],
+    }
+
+    return {
+        "meta": meta,
+        "angles": angles,
+        "houses": houses,
+        "classification": classification,
+    }
+
+
+__all__ = [
+    "HouseRequest",
+    "compute_houses",
+    "compute_angles_native",
+    "compute_sripati_from_angles",
+    "to_sidereal",
+]

--- a/tests/test_houses.py
+++ b/tests/test_houses.py
@@ -1,0 +1,59 @@
+import math
+
+from astrocore.houses import HouseRequest, compute_houses
+
+
+REQ_ARGS = dict(
+    jd_ut=2447013.856,
+    geo_lat_deg=44.7153,
+    geo_lon_deg=42.9979,
+    ayanamsa="Lahiri",
+)
+
+
+def test_whole_sign_houses_structure():
+    req = HouseRequest(
+        **REQ_ARGS,
+        house_system="whole-sign",
+        backend="native",
+        options={"return_width": True},
+    )
+    data = compute_houses(req)
+
+    houses = data["houses"]
+    angles = data["angles"]
+
+    assert houses["type"] == "sign-based"
+    borders = houses["borders_deg_sid"]
+    assert len(borders) == 12
+    # first border is start of the ascendant sign
+    asc = angles["asc_deg_sid"]
+    expected_start = math.floor(asc / 30.0) * 30.0
+    assert math.isclose(borders[0], expected_start, abs_tol=1e-6)
+    # consecutive borders differ by 30 degrees
+    diffs = [
+        (borders[(i + 1) % 12] - borders[i]) % 360.0 for i in range(12)
+    ]
+    assert all(math.isclose(d, 30.0, abs_tol=1e-6) for d in diffs)
+    # widths are all 30 degrees
+    assert houses["width_deg"] == [30.0] * 12
+
+
+def test_sripati_cusps_consistency():
+    req = HouseRequest(
+        **REQ_ARGS,
+        house_system="sripati",
+        backend="native",
+        options={"return_borders": True, "return_width": True},
+    )
+    data = compute_houses(req)
+    houses = data["houses"]
+    angles = data["angles"]
+
+    cusps = houses["cusps_deg_sid"]
+    assert len(cusps) == 12
+    # cusp 1 equals ascendant; cusp 10 equals midheaven
+    assert math.isclose(cusps[0], angles["asc_deg_sid"], abs_tol=1e-6)
+    assert math.isclose(cusps[9], angles["mc_deg_sid"], abs_tol=1e-6)
+    # widths sum to 360 degrees
+    assert math.isclose(sum(houses["width_deg"]), 360.0, abs_tol=1e-6)


### PR DESCRIPTION
## Summary
- add module for computing whole-sign and cuspal (Śrīpati/Placidus) house data
- expose Swiss Ephemeris houses_ex wrapper for system selection
- add tests for whole-sign and Śrīpati house computations

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b099252d308325a928ec59f60ec3ef