### PR TITLE
feat: add house cusp calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Minimal astrological core calculations using Swiss Ephemeris.
 
+## Houses
+
+`astrocore.houses.compute_houses` returns house cusps, borders and widths in a
+unified structure for Whole-sign, Śrīpati and Placidus systems.  All longitudes
+are sidereal and normalised to `[0, 360)`.
+
 ## Example
 
 ```python

--- a/astrocore/config.py
+++ b/astrocore/config.py
@@ -12,4 +12,5 @@ DEFAULT_EPHE_PATH = Path(os.environ.get("EPHE_PATH", Path(__file__).resolve().pa
 # Mapping of ayanamsa identifiers to Swiss Ephemeris constants
 AYANAMSA_MAP = {
     "Lahiri": swe.SIDM_LAHIRI,
+    "Krishnamurti": swe.SIDM_KRISHNAMURTI,
 }

--- a/astrocore/eph/swiss.py
+++ b/astrocore/eph/swiss.py
@@ -24,6 +24,16 @@ def init_ephemeris(ephe_path: str | None = None, ayanamsa: str = "Lahiri", sider
         _initialized = True
 
 
+def set_sid_mode(name: str) -> None:
+    """Switch Swiss ephemeris sidereal mode by name."""
+
+    sid = AYANAMSA_MAP.get(name)
+    if sid is None:
+        raise ValueError(f"unknown ayanamsa {name}")
+    with _swe_lock:
+        swe.set_sid_mode(sid)
+
+
 def calc_ut(jd_ut: float, body: int, flags: int) -> Dict[str, Any]:
     """Thread-safe wrapper around ``swe.calc_ut``."""
     with _swe_lock:
@@ -40,6 +50,12 @@ def houses(jd_ut: float, lat: float, lon: float):
     """Thread-safe wrapper around ``swe.houses``."""
     with _swe_lock:
         return swe.houses(jd_ut, lat, lon)
+
+
+def houses_ex(jd_ut: float, lat: float, lon: float, hsys: bytes):
+    """Thread-safe wrapper around ``swe.houses_ex`` allowing house system selection."""
+    with _swe_lock:
+        return swe.houses_ex(jd_ut, lat, lon, hsys)
 
 
 def get_ayanamsa(jd_ut: float) -> float:

--- a/astrocore/houses.py
+++ b/astrocore/houses.py
@@ -1,0 +1,260 @@
+"""House calculations for astrocore.
+
+The module exposes :func:`compute_houses` which returns a unified contract for
+all supported house systems.  The contract is built around three arrays:
+
+``cusps_deg_sid`` – midpoints of houses (bhāva-madhya) in sidereal longitude.
+``borders_deg_sid`` – house borders (bhāva-sandhi); optional.
+``width_deg`` – widths of houses on the ecliptic; optional.
+
+Every array, when present, has length 12 with index ``0`` corresponding to the
+first house.  Values are normalised to ``[0, 360)``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal, Dict, List
+import math
+
+from .eph import swiss
+from .eph.base_core import compute_geometry
+from .utils.angles import mod360
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class HouseRequest:
+    jd_ut: float
+    geo_lat_deg: float
+    geo_lon_deg: float
+    ayanamsa: str = "Lahiri"
+    house_system: Literal["whole-sign", "sripati", "placidus"] = "whole-sign"
+    backend: Literal["auto", "swiss", "native"] = "auto"
+    options: Dict[str, object] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+WSH_EPS = 1e-9
+
+
+def to_sidereal(lon_trop_deg: float, ayanamsa_value_deg: float) -> float:
+    """Convert a tropical longitude to sidereal using given ayanamsa."""
+    return mod360(lon_trop_deg - ayanamsa_value_deg)
+
+
+def compute_angles_native(jd_ut: float, lat: float, lon: float,
+                          epsilon_mode: str = "true-of-date") -> Dict[str, float]:
+    """Return Ascendant and Midheaven longitudes in the tropical zodiac.
+
+    Uses a Swiss Ephemeris call with the Porphyry system to ensure validity
+    across all latitudes without incurring Placidus errors.
+    """
+
+    _, ascmc = swiss.houses_ex(jd_ut, lat, lon, b"O")
+    return {"asc_deg": ascmc[0], "mc_deg": ascmc[1]}
+
+
+def compute_sripati_from_angles(asc: float, mc: float) -> List[float]:
+    """Compute Śrīpati (Porphyry) house *cusps* from Asc and MC (sidereal).
+
+    Returned array contains midpoints of houses starting from index 0 = house I.
+    """
+
+    asc = mod360(asc)
+    mc = mod360(mc)
+    ic = mod360(mc + 180.0)
+    desc = mod360(asc + 180.0)
+    cusps = [0.0] * 12
+    cusps[0] = asc  # 1st house
+    cusps[3] = ic   # 4th house
+    cusps[6] = desc # 7th house
+    cusps[9] = mc   # 10th house
+
+    arc_mc_asc = (asc - mc) % 360.0
+    step1 = arc_mc_asc / 3.0
+    cusps[10] = mod360(mc + step1)        # 11th
+    cusps[11] = mod360(mc + 2 * step1)    # 12th
+    cusps[4] = mod360(cusps[10] + 180.0)  # 5th
+    cusps[5] = mod360(cusps[11] + 180.0)  # 6th
+
+    arc_asc_ic = (ic - asc) % 360.0
+    step2 = arc_asc_ic / 3.0
+    cusps[1] = mod360(asc + step2)        # 2nd
+    cusps[2] = mod360(asc + 2 * step2)    # 3rd
+    cusps[7] = mod360(cusps[1] + 180.0)   # 8th
+    cusps[8] = mod360(cusps[2] + 180.0)   # 9th
+
+    return [mod360(c) for c in cusps]
+
+
+def widths_from_borders(borders: List[float]) -> List[float]:
+    """Compute widths between consecutive borders."""
+
+    return [
+        (borders[(i + 1) % 12] - borders[i]) % 360.0
+        for i in range(12)
+    ]
+
+
+def madhya_from_borders(borders: List[float]) -> List[float]:
+    """Return midpoints (cusps) for given borders."""
+
+    widths = widths_from_borders(borders)
+    return [mod360(borders[i] + widths[i] / 2.0) for i in range(12)]
+
+
+def borders_from_madhya(cusps: List[float]) -> List[float]:
+    """Infer borders from cusps midpoints."""
+
+    borders: List[float] = []
+    for i in range(12):
+        prev = cusps[i - 1]
+        cur = cusps[i]
+        diff = (cur - prev) % 360.0
+        borders.append(mod360(prev + diff / 2.0))
+    return borders
+
+
+def _whole_sign_borders(asc_sid: float) -> List[float]:
+    """Internal helper for Whole-sign borders using EPS to handle boundaries."""
+
+    start = math.floor((asc_sid - WSH_EPS) / 30.0) * 30.0
+    return [mod360(start + i * 30.0) for i in range(12)]
+
+
+# ---------------------------------------------------------------------------
+# Main entry
+# ---------------------------------------------------------------------------
+
+def compute_houses(req: HouseRequest) -> Dict[str, object]:
+    """Return house data according to :class:`HouseRequest`.
+
+    The result dictionary contains ``meta``, ``angles``, ``houses`` and
+    ``classification`` keys.  ``houses`` follow the contract described in the
+    module docstring.
+    """
+
+    backend = req.backend
+    if backend == "auto":
+        backend = "native" if req.house_system in ("whole-sign", "sripati") else "swiss"
+
+    options = req.options or {}
+    return_borders = bool(options.get("return_borders"))
+    return_width = bool(options.get("return_width"))
+
+    status = "ok"
+    notes = ""
+
+    ayan_name = req.ayanamsa
+    try:
+        swiss.set_sid_mode(ayan_name)
+    except ValueError:
+        ayan_name = "Lahiri"
+        status = "warn"
+        notes = f"unknown ayanamsa {req.ayanamsa}, fallback to Lahiri"
+        swiss.set_sid_mode(ayan_name)
+
+    geometry = compute_geometry(req.jd_ut, req.geo_lat_deg, req.geo_lon_deg)
+    ayan_deg = geometry["ayanamsa_value_deg"]
+    ramc_deg = geometry["armc_deg"]
+    lst_deg = ramc_deg  # alias for backwards compatibility
+    epsilon_deg = geometry["epsilon_deg"]
+
+    houses: Dict[str, object] = {}
+    angles: Dict[str, float] = {}
+
+    if req.house_system == "placidus" and backend == "swiss":
+        try:
+            borders_trop, ascmc = swiss.houses_ex(
+                req.jd_ut, req.geo_lat_deg, req.geo_lon_deg, b"P"
+            )
+            asc_trop, mc_trop = ascmc[0], ascmc[1]
+            borders_sid = [to_sidereal(b, ayan_deg) for b in borders_trop]
+            cusps_sid = madhya_from_borders(borders_sid)
+
+            houses["type"] = "cuspal"
+            houses["cusps_deg_sid"] = cusps_sid
+            if return_borders:
+                houses["borders_deg_sid"] = borders_sid
+            if return_width:
+                houses["width_deg"] = widths_from_borders(borders_sid)
+
+            angles["asc_deg_sid"] = to_sidereal(asc_trop, ayan_deg)
+            angles["mc_deg_sid"] = to_sidereal(mc_trop, ayan_deg)
+        except Exception:
+            backend = "native"
+            status = "fallback"
+            notes = "fallback to sripati because placidus undefined at latitude"
+
+    if not angles:  # Whole-sign or Śrīpати or fallback branch
+        ang = compute_angles_native(req.jd_ut, req.geo_lat_deg, req.geo_lon_deg)
+        asc_sid = to_sidereal(ang["asc_deg"], ayan_deg)
+        mc_sid = to_sidereal(ang["mc_deg"], ayan_deg)
+        angles["asc_deg_sid"] = asc_sid
+        angles["mc_deg_sid"] = mc_sid
+
+        if req.house_system == "whole-sign":
+            houses["type"] = "sign-based"
+            borders = _whole_sign_borders(asc_sid)
+            cusps = [mod360(b + 15.0) for b in borders]
+            houses["cusps_deg_sid"] = cusps
+            houses["madhya_deg_sid"] = cusps[:]  # alias for compatibility
+            if return_borders:
+                houses["borders_deg_sid"] = borders
+            if return_width:
+                houses["width_deg"] = [30.0] * 12
+        else:  # Śrīpati or placidus fallback
+            houses["type"] = "cuspal"
+            cusps = compute_sripati_from_angles(asc_sid, mc_sid)
+            houses["cusps_deg_sid"] = cusps
+            if return_borders or return_width:
+                borders = borders_from_madhya(cusps)
+                if return_borders:
+                    houses["borders_deg_sid"] = borders
+                if return_width:
+                    houses["width_deg"] = widths_from_borders(borders)
+
+    angles["desc_deg_sid"] = mod360(angles["asc_deg_sid"] + 180.0)
+    angles["ic_deg_sid"] = mod360(angles["mc_deg_sid"] + 180.0)
+
+    meta = {
+        "house_system": req.house_system,
+        "backend": backend,
+        "ayanamsa": {"name": ayan_name, "value_deg": ayan_deg},
+        "lst_deg": lst_deg,  # alias of RAMC
+        "epsilon_deg": epsilon_deg,
+        "ramc_deg": ramc_deg,
+        "status": status,
+    }
+    if notes:
+        meta["notes"] = notes
+
+    classification = {
+        "kendra": [1, 4, 7, 10],
+        "trikona": [1, 5, 9],
+        "upachaya": [3, 6, 10, 11],
+        "dusthana": [6, 8, 12],
+    }
+
+    return {
+        "meta": meta,
+        "angles": angles,
+        "houses": houses,
+        "classification": classification,
+    }
+
+
+__all__ = [
+    "HouseRequest",
+    "compute_houses",
+    "compute_sripati_from_angles",
+    "compute_angles_native",
+    "to_sidereal",
+]
+

--- a/tests/test_houses.py
+++ b/tests/test_houses.py
@@ -1,0 +1,136 @@
+"""Tests for house computations."""
+
+import json
+import math
+
+from astrocore.houses import (
+    HouseRequest,
+    compute_houses,
+    _whole_sign_borders,
+)
+
+
+REQ_ARGS = dict(
+    jd_ut=2447013.856,
+    geo_lat_deg=44.7153,
+    geo_lon_deg=42.9979,
+)
+
+
+def test_whole_sign_eps_boundary():
+    borders = _whole_sign_borders(30.0 + 1e-8)
+    assert math.isclose(borders[0], 30.0, abs_tol=1e-12)
+    borders = _whole_sign_borders(30.0)
+    assert math.isclose(borders[0], 0.0, abs_tol=1e-12)
+
+
+def test_whole_sign_structure():
+    req = HouseRequest(
+        **REQ_ARGS,
+        house_system="whole-sign",
+        options={"return_borders": True, "return_width": True},
+    )
+    data = compute_houses(req)
+    print("Whole-sign houses output:\n" + json.dumps(data, indent=2, sort_keys=True))
+
+    houses = data["houses"]
+    angles = data["angles"]
+
+    assert houses["type"] == "sign-based"
+    borders = houses["borders_deg_sid"]
+    cusps = houses["cusps_deg_sid"]
+    assert len(borders) == len(cusps) == 12
+
+    expected_start = math.floor((angles["asc_deg_sid"] - 1e-9) / 30.0) * 30.0
+    assert math.isclose(borders[0], expected_start, abs_tol=1e-6)
+
+    # cusps are borders + 15° and widths are all 30°
+    for b, c in zip(borders, cusps):
+        assert math.isclose(c, (b + 15.0) % 360.0, abs_tol=1e-6)
+    assert houses["width_deg"] == [30.0] * 12
+
+
+def test_sripati_consistency():
+    req = HouseRequest(
+        **REQ_ARGS,
+        house_system="sripati",
+        options={"return_borders": True, "return_width": True},
+    )
+    data = compute_houses(req)
+    print("Śrīpati houses output:\n" + json.dumps(data, indent=2, sort_keys=True))
+    houses = data["houses"]
+    angles = data["angles"]
+
+    cusps = houses["cusps_deg_sid"]
+    borders = houses["borders_deg_sid"]
+    widths = houses["width_deg"]
+    assert len(cusps) == len(borders) == len(widths) == 12
+
+    assert math.isclose(cusps[0], angles["asc_deg_sid"], abs_tol=1e-6)
+    assert math.isclose(cusps[9], angles["mc_deg_sid"], abs_tol=1e-6)
+
+    for i in range(12):
+        mid = (cusps[i - 1] + ((cusps[i] - cusps[i - 1]) % 360.0) / 2.0) % 360.0
+        assert math.isclose(borders[i], mid, abs_tol=1e-6)
+        expected_width = (borders[(i + 1) % 12] - borders[i]) % 360.0
+        assert math.isclose(widths[i], expected_width, abs_tol=1e-6)
+
+    assert math.isclose(sum(widths), 360.0, abs_tol=1e-6)
+
+
+def test_placidus_contract():
+    req = HouseRequest(
+        **REQ_ARGS,
+        house_system="placidus",
+        backend="swiss",
+        options={"return_borders": True, "return_width": True},
+    )
+    data = compute_houses(req)
+    houses = data["houses"]
+    angles = data["angles"]
+
+    borders = houses["borders_deg_sid"]
+    cusps = houses["cusps_deg_sid"]
+    widths = houses["width_deg"]
+
+    assert math.isclose(borders[0], angles["asc_deg_sid"], abs_tol=1e-6)
+    assert math.isclose(borders[9], angles["mc_deg_sid"], abs_tol=1e-6)
+
+    for i in range(12):
+        mid = (borders[i] + ((borders[(i + 1) % 12] - borders[i]) % 360.0) / 2.0) % 360.0
+        assert math.isclose(cusps[i], mid, abs_tol=1e-6)
+        expected_width = (borders[(i + 1) % 12] - borders[i]) % 360.0
+        assert math.isclose(widths[i], expected_width, abs_tol=1e-6)
+
+    assert math.isclose(sum(widths), 360.0, abs_tol=1e-6)
+
+
+def test_placidus_fallback_high_latitude():
+    req = HouseRequest(
+        jd_ut=2447013.856,
+        geo_lat_deg=70.0,
+        geo_lon_deg=0.0,
+        ayanamsa="Lahiri",
+        house_system="placidus",
+    )
+    data = compute_houses(req)
+    meta = data["meta"]
+    assert meta["status"] == "fallback"
+    assert "placidus undefined" in meta["notes"]
+
+
+def test_ayanamsa_switch_changes_values():
+    req1 = HouseRequest(**REQ_ARGS, ayanamsa="Lahiri")
+    req2 = HouseRequest(**REQ_ARGS, ayanamsa="Krishnamurti")
+
+    data1 = compute_houses(req1)
+    data2 = compute_houses(req2)
+
+    val1 = data1["meta"]["ayanamsa"]["value_deg"]
+    val2 = data2["meta"]["ayanamsa"]["value_deg"]
+    assert not math.isclose(val1, val2, abs_tol=1e-3)
+
+    asc1 = data1["angles"]["asc_deg_sid"]
+    asc2 = data2["angles"]["asc_deg_sid"]
+    assert not math.isclose(asc1, asc2, abs_tol=1e-3)
+


### PR DESCRIPTION
## Summary
- unify house-system contract returning cusps, borders and widths
- add sidereal mode switching and ayanamsa handling
- correct Placidus treatment via border midpoints with fallback to Śrīpati
- include tests for whole-sign boundaries, Placidus contract and ayanamsa switching

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b099252d308325a928ec59f60ec3ef