### PR TITLE
Unify axis key naming across axes and houses

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Minimal astrological core calculations using Swiss Ephemeris.
 unified structure for Whole-sign, Śrīpati and Placidus systems.  All longitudes
 are sidereal and normalised to `[0, 360)`.
 
+Ascendant and Midheaven axes are exposed in both sidereal and tropical
+longitudes using the keys `asc_deg_sid`, `mc_deg_sid`, `asc_deg_trop`, and
+`mc_deg_trop`.
+
 ## Example
 
 ```python
@@ -27,5 +31,6 @@ payload = {
     },
 }
 result = build_base_core(payload)
+print(result["axes"]["asc_deg_sid"], result["axes"]["mc_deg_sid"])
 print(result["bodies"]["Sun"])
 ```

--- a/astrocore/eph/axes.py
+++ b/astrocore/eph/axes.py
@@ -12,9 +12,11 @@ def compute_axes(jd_ut: float, ayanamsa_deg: float, lat: float, lon: float) -> D
     cusps, ascmc = swiss.houses(jd_ut, lat, lon)
     asc_trop = ascmc[0]
     mc_trop = ascmc[1]
+    asc_sid = mod360(asc_trop - ayanamsa_deg)
+    mc_sid = mod360(mc_trop - ayanamsa_deg)
     return {
-        "asc_tropical_lon_deg": asc_trop,
-        "mc_tropical_lon_deg": mc_trop,
-        "asc_sidereal_lon_deg": mod360(asc_trop - ayanamsa_deg),
-        "mc_sidereal_lon_deg": mod360(mc_trop - ayanamsa_deg),
+        "asc_deg_sid": asc_sid,
+        "mc_deg_sid": mc_sid,
+        "asc_deg_trop": asc_trop,
+        "mc_deg_trop": mc_trop,
     }

--- a/astrocore/eph/base_core.py
+++ b/astrocore/eph/base_core.py
@@ -39,7 +39,9 @@ def build_base_core(payload: BaseInput) -> CoreOutput:
     start = perf_counter()
     t = compute_time(payload["date"], payload["time"], payload["tz_offset_hours"])
     geometry = compute_geometry(t["jd_ut"], payload["latitude"], payload["longitude"])
-    axes = compute_axes(t["jd_ut"], geometry["ayanamsa_value_deg"], payload["latitude"], payload["longitude"])
+    axes = compute_axes(
+        t["jd_ut"], geometry["ayanamsa_value_deg"], payload["latitude"], payload["longitude"]
+    )  # keys: asc_deg_sid, mc_deg_sid, asc_deg_trop, mc_deg_trop
     bodies = compute_bodies(
         t["jd_ut"],
         settings,

--- a/astrocore/houses.py
+++ b/astrocore/houses.py
@@ -52,8 +52,9 @@ def to_sidereal(lon_trop_deg: float, ayanamsa_value_deg: float) -> float:
     return mod360(lon_trop_deg - ayanamsa_value_deg)
 
 
-def compute_angles_native(jd_ut: float, lat: float, lon: float,
-                          epsilon_mode: str = "true-of-date") -> Dict[str, float]:
+def compute_angles_native(
+    jd_ut: float, lat: float, lon: float, epsilon_mode: str = "true-of-date"
+) -> Dict[str, float]:
     """Return Ascendant and Midheaven longitudes in the tropical zodiac.
 
     Uses a Swiss Ephemeris call with the Porphyry system to ensure validity
@@ -61,7 +62,7 @@ def compute_angles_native(jd_ut: float, lat: float, lon: float,
     """
 
     _, ascmc = swiss.houses_ex(jd_ut, lat, lon, b"O")
-    return {"asc_deg": ascmc[0], "mc_deg": ascmc[1]}
+    return {"asc_deg_trop": ascmc[0], "mc_deg_trop": ascmc[1]}
 
 
 def compute_sripati_from_angles(asc: float, mc: float) -> List[float]:
@@ -202,8 +203,8 @@ def compute_houses(req: HouseRequest) -> Dict[str, object]:
 
     if not angles:  # Whole-sign or Śrīpати or fallback branch
         ang = compute_angles_native(req.jd_ut, req.geo_lat_deg, req.geo_lon_deg)
-        asc_sid = to_sidereal(ang["asc_deg"], ayan_deg)
-        mc_sid = to_sidereal(ang["mc_deg"], ayan_deg)
+        asc_sid = to_sidereal(ang["asc_deg_trop"], ayan_deg)
+        mc_sid = to_sidereal(ang["mc_deg_trop"], ayan_deg)
         angles["asc_deg_sid"] = asc_sid
         angles["mc_deg_sid"] = mc_sid
 

--- a/tests/test_print_output.py
+++ b/tests/test_print_output.py
@@ -28,6 +28,14 @@ def test_print_core_output() -> None:
     core = build_base_core(payload)
     print(json.dumps(core, indent=2, sort_keys=True))
 
+    # Ensure unified axis key names are present
+    assert set(core["axes"].keys()) == {
+        "asc_deg_sid",
+        "mc_deg_sid",
+        "asc_deg_trop",
+        "mc_deg_trop",
+    }
+
     # Extra formatted output: planetary positions within zodiac signs
     from derived.signs import lon_to_sign_deg
 


### PR DESCRIPTION
## Summary
- Standardize axis dictionary keys to `asc_deg_sid`, `mc_deg_sid`, `asc_deg_trop`, and `mc_deg_trop`
- Align house calculations and docs with the new naming scheme
- Add regression test to verify axis keys in base core output

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2ae034734832594c1149486c52f02