### PR TITLE
refactor: unify ayanamsa naming

### DIFF
--- a/astrocore/eph/base_core.py
+++ b/astrocore/eph/base_core.py
@@ -23,7 +23,7 @@ def compute_geometry(jd_ut: float, lat: float, lon: float) -> Dict[str, float]:
     lst_hours = (gst_hours + lon / 15.0) % 24.0
     armc_deg = (lst_hours * 15.0) % 360.0
     return {
-        "ayanamsa_value_deg": ayanamsa_deg,
+        "ayanamsa_deg": ayanamsa_deg,
         "epsilon_deg": epsilon,
         "gst_hours": gst_hours,
         "lst_hours": lst_hours,
@@ -40,12 +40,12 @@ def build_base_core(payload: BaseInput) -> CoreOutput:
     t = compute_time(payload["date"], payload["time"], payload["tz_offset_hours"])
     geometry = compute_geometry(t["jd_ut"], payload["latitude"], payload["longitude"])
     axes = compute_axes(
-        t["jd_ut"], geometry["ayanamsa_value_deg"], payload["latitude"], payload["longitude"]
+        t["jd_ut"], geometry["ayanamsa_deg"], payload["latitude"], payload["longitude"]
     )  # keys: asc_deg_sid, mc_deg_sid, asc_deg_trop, mc_deg_trop
     bodies = compute_bodies(
         t["jd_ut"],
         settings,
-        geometry["ayanamsa_value_deg"],
+        geometry["ayanamsa_deg"],
         payload["latitude"],
         payload["longitude"],
     )

--- a/tests/test_houses.py
+++ b/tests/test_houses.py
@@ -134,8 +134,8 @@ def test_ayanamsa_switch_changes_values():
     data1 = compute_houses(req1)
     data2 = compute_houses(req2)
 
-    val1 = data1["meta"]["ayanamsa"]["value_deg"]
-    val2 = data2["meta"]["ayanamsa"]["value_deg"]
+    val1 = data1["meta"]["ayanamsa_deg"]
+    val2 = data2["meta"]["ayanamsa_deg"]
     assert not math.isclose(val1, val2, abs_tol=1e-3)
 
     asc1 = data1["angles"]["asc_deg_sid"]

--- a/tests/test_print_output.py
+++ b/tests/test_print_output.py
@@ -28,6 +28,9 @@ def test_print_core_output() -> None:
     core = build_base_core(payload)
     print(json.dumps(core, indent=2, sort_keys=True))
 
+    # Verify ayanamsa value is exposed with the new key
+    assert "ayanamsa_deg" in core["geometry"]
+
     # Ensure unified axis key names are present
     assert set(core["axes"].keys()) == {
         "asc_deg_sid",


### PR DESCRIPTION
## Summary
- replace `ayanamsa_value_deg` with `ayanamsa_deg`
- use `ayanamsa_name`/`ayanamsa_deg` consistently in house metadata
- update tests for renamed fields

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2b086cd488325952ac1924628fa3b