### PR TITLE
Remove lst_deg alias from house metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Unreleased
+- Removed `lst_deg` metadata alias from `compute_houses`; use `ramc_deg` instead.

--- a/README.md
+++ b/README.md
@@ -34,3 +34,8 @@ result = build_base_core(payload)
 print(result["axes"]["asc_deg_sid"], result["axes"]["mc_deg_sid"])
 print(result["bodies"]["Sun"])
 ```
+
+## Changelog
+
+- `lst_deg` metadata alias has been removed from `compute_houses`; use
+  `ramc_deg` as the canonical key for the right ascension of the Midheaven.

--- a/astrocore/houses.py
+++ b/astrocore/houses.py
@@ -172,7 +172,6 @@ def compute_houses(req: HouseRequest) -> Dict[str, object]:
     geometry = compute_geometry(req.jd_ut, req.geo_lat_deg, req.geo_lon_deg)
     ayanamsa_deg = geometry["ayanamsa_deg"]
     ramc_deg = geometry["armc_deg"]
-    lst_deg = ramc_deg  # alias for backwards compatibility
     epsilon_deg = geometry["epsilon_deg"]
 
     houses: Dict[str, object] = {}
@@ -237,7 +236,6 @@ def compute_houses(req: HouseRequest) -> Dict[str, object]:
         "backend": backend,
         "ayanamsa_name": ayanamsa_name,
         "ayanamsa_deg": ayanamsa_deg,
-        "lst_deg": lst_deg,  # alias of RAMC
         "epsilon_deg": epsilon_deg,
         "ramc_deg": ramc_deg,
 


### PR DESCRIPTION
## Summary
- drop outdated `lst_deg` alias from `compute_houses` metadata
- document `ramc_deg` as canonical key for right ascension
- note change in changelog

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2b1e1e2cc83259fbb1699aea18cc1