### PR TITLE
Rename armc_deg to ramc_deg and update houses metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
 
 ## Unreleased
-- Removed `lst_deg` metadata alias from `compute_houses`; use `ramc_deg` instead.
+- Renamed geometry key `armc_deg` to `ramc_deg` and removed the `lst_deg`
+  metadata alias from `compute_houses`.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ are sidereal and normalised to `[0, 360)`.
 
 Ascendant and Midheaven axes are exposed in both sidereal and tropical
 longitudes using the keys `asc_deg_sid`, `mc_deg_sid`, `asc_deg_trop`, and
-`mc_deg_trop`.
+`mc_deg_trop`. Metadata also includes the right ascension of the Midheaven
+as `ramc_deg`.
 
 ## Example
 
@@ -37,5 +38,5 @@ print(result["bodies"]["Sun"])
 
 ## Changelog
 
-- `lst_deg` metadata alias has been removed from `compute_houses`; use
-  `ramc_deg` as the canonical key for the right ascension of the Midheaven.
+- Renamed geometry key `armc_deg` to `ramc_deg` and removed the `lst_deg`
+  metadata alias from `compute_houses`.

--- a/astrocore/eph/base_core.py
+++ b/astrocore/eph/base_core.py
@@ -21,13 +21,13 @@ def compute_geometry(jd_ut: float, lat: float, lon: float) -> Dict[str, float]:
     epsilon = swiss.ecl_nut(jd_ut)[0]
     gst_hours = swiss.sidtime(jd_ut)
     lst_hours = (gst_hours + lon / 15.0) % 24.0
-    armc_deg = (lst_hours * 15.0) % 360.0
+    ramc_deg = (lst_hours * 15.0) % 360.0
     return {
         "ayanamsa_deg": ayanamsa_deg,
         "epsilon_deg": epsilon,
         "gst_hours": gst_hours,
         "lst_hours": lst_hours,
-        "armc_deg": armc_deg,
+        "ramc_deg": ramc_deg,
     }
 
 

--- a/astrocore/houses.py
+++ b/astrocore/houses.py
@@ -171,7 +171,7 @@ def compute_houses(req: HouseRequest) -> Dict[str, object]:
 
     geometry = compute_geometry(req.jd_ut, req.geo_lat_deg, req.geo_lon_deg)
     ayanamsa_deg = geometry["ayanamsa_deg"]
-    ramc_deg = geometry["armc_deg"]
+    ramc_deg = geometry["ramc_deg"]
     epsilon_deg = geometry["epsilon_deg"]
 
     houses: Dict[str, object] = {}

--- a/tests/test_houses.py
+++ b/tests/test_houses.py
@@ -39,6 +39,7 @@ def test_whole_sign_structure():
 
     houses = data["houses"]
     angles = data["angles"]
+    assert "ramc_deg" in data["meta"]
 
     assert houses["type"] == "sign-based"
     borders = houses["borders_deg_sid"]

--- a/tests/test_print_output.py
+++ b/tests/test_print_output.py
@@ -30,6 +30,7 @@ def test_print_core_output() -> None:
 
     # Verify ayanamsa value is exposed with the new key
     assert "ayanamsa_deg" in core["geometry"]
+    assert "ramc_deg" in core["geometry"]
 
     # Ensure unified axis key names are present
     assert set(core["axes"].keys()) == {


### PR DESCRIPTION
## Summary
- expose Right Ascension of the Midheaven as `ramc_deg`
- read `ramc_deg` in house calculations and metadata
- document and test the new key

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2b6e735a483258b75276f5f861834