### PR TITLE
Unify axes key for house computations

### DIFF
--- a/astrocore/houses.py
+++ b/astrocore/houses.py
@@ -142,7 +142,7 @@ def _whole_sign_borders(asc_sid: float) -> List[float]:
 def compute_houses(req: HouseRequest) -> Dict[str, object]:
     """Return house data according to :class:`HouseRequest`.
 
-    The result dictionary contains ``meta``, ``angles``, ``houses`` and
+    The result dictionary contains ``meta``, ``axes``, ``houses`` and
     ``classification`` keys.  ``houses`` follow the contract described in the
     module docstring.
     """
@@ -175,7 +175,7 @@ def compute_houses(req: HouseRequest) -> Dict[str, object]:
     epsilon_deg = geometry["epsilon_deg"]
 
     houses: Dict[str, object] = {}
-    angles: Dict[str, float] = {}
+    axes: Dict[str, float] = {}
 
     if req.house_system == "placidus" and backend == "swiss":
         try:
@@ -193,19 +193,19 @@ def compute_houses(req: HouseRequest) -> Dict[str, object]:
             if return_width:
                 houses["width_deg"] = widths_from_borders(borders_sid)
 
-            angles["asc_deg_sid"] = to_sidereal(asc_trop, ayanamsa_deg)
-            angles["mc_deg_sid"] = to_sidereal(mc_trop, ayanamsa_deg)
+            axes["asc_deg_sid"] = to_sidereal(asc_trop, ayanamsa_deg)
+            axes["mc_deg_sid"] = to_sidereal(mc_trop, ayanamsa_deg)
         except Exception:
             backend = "native"
             status = "fallback"
             notes = "fallback to sripati because placidus undefined at latitude"
 
-    if not angles:  # Whole-sign or Śrīpати or fallback branch
+    if not axes:  # Whole-sign or Śrīpати or fallback branch
         ang = compute_angles_native(req.jd_ut, req.geo_lat_deg, req.geo_lon_deg)
         asc_sid = to_sidereal(ang["asc_deg_trop"], ayanamsa_deg)
         mc_sid = to_sidereal(ang["mc_deg_trop"], ayanamsa_deg)
-        angles["asc_deg_sid"] = asc_sid
-        angles["mc_deg_sid"] = mc_sid
+        axes["asc_deg_sid"] = asc_sid
+        axes["mc_deg_sid"] = mc_sid
 
         if req.house_system == "whole-sign":
             houses["type"] = "sign-based"
@@ -228,8 +228,8 @@ def compute_houses(req: HouseRequest) -> Dict[str, object]:
                 if return_width:
                     houses["width_deg"] = widths_from_borders(borders)
 
-    angles["desc_deg_sid"] = mod360(angles["asc_deg_sid"] + 180.0)
-    angles["ic_deg_sid"] = mod360(angles["mc_deg_sid"] + 180.0)
+    axes["desc_deg_sid"] = mod360(axes["asc_deg_sid"] + 180.0)
+    axes["ic_deg_sid"] = mod360(axes["mc_deg_sid"] + 180.0)
 
     meta = {
         "house_system": req.house_system,
@@ -253,7 +253,7 @@ def compute_houses(req: HouseRequest) -> Dict[str, object]:
 
     return {
         "meta": meta,
-        "angles": angles,
+        "axes": axes,
         "houses": houses,
         "classification": classification,
     }

--- a/tests/test_houses.py
+++ b/tests/test_houses.py
@@ -38,7 +38,7 @@ def test_whole_sign_structure():
     print("Whole-sign houses output:\n" + json.dumps(data, indent=2, sort_keys=True))
 
     houses = data["houses"]
-    angles = data["angles"]
+    axes = data["axes"]
 
     assert houses["type"] == "sign-based"
     borders = houses["borders_deg_sid"]
@@ -46,7 +46,7 @@ def test_whole_sign_structure():
     cusps = houses["cusps_deg_sid"]
     assert len(borders) == len(cusps) == 12
 
-    expected_start = math.floor((angles["asc_deg_sid"] - 1e-9) / 30.0) * 30.0
+    expected_start = math.floor((axes["asc_deg_sid"] - 1e-9) / 30.0) * 30.0
     assert math.isclose(borders[0], expected_start, abs_tol=1e-6)
 
     # cusps are borders + 15° and widths are all 30°
@@ -66,7 +66,7 @@ def test_sripati_consistency():
     print("Śrīpati houses output:\n" + json.dumps(data, indent=2, sort_keys=True))
 
     houses = data["houses"]
-    angles = data["angles"]
+    axes = data["axes"]
 
     cusps = houses["cusps_deg_sid"]
 
@@ -74,8 +74,8 @@ def test_sripati_consistency():
     widths = houses["width_deg"]
     assert len(cusps) == len(borders) == len(widths) == 12
 
-    assert math.isclose(cusps[0], angles["asc_deg_sid"], abs_tol=1e-6)
-    assert math.isclose(cusps[9], angles["mc_deg_sid"], abs_tol=1e-6)
+    assert math.isclose(cusps[0], axes["asc_deg_sid"], abs_tol=1e-6)
+    assert math.isclose(cusps[9], axes["mc_deg_sid"], abs_tol=1e-6)
 
     for i in range(12):
         mid = (cusps[i - 1] + ((cusps[i] - cusps[i - 1]) % 360.0) / 2.0) % 360.0
@@ -95,14 +95,14 @@ def test_placidus_contract():
     )
     data = compute_houses(req)
     houses = data["houses"]
-    angles = data["angles"]
+    axes = data["axes"]
 
     borders = houses["borders_deg_sid"]
     cusps = houses["cusps_deg_sid"]
     widths = houses["width_deg"]
 
-    assert math.isclose(borders[0], angles["asc_deg_sid"], abs_tol=1e-6)
-    assert math.isclose(borders[9], angles["mc_deg_sid"], abs_tol=1e-6)
+    assert math.isclose(borders[0], axes["asc_deg_sid"], abs_tol=1e-6)
+    assert math.isclose(borders[9], axes["mc_deg_sid"], abs_tol=1e-6)
 
     for i in range(12):
         mid = (borders[i] + ((borders[(i + 1) % 12] - borders[i]) % 360.0) / 2.0) % 360.0
@@ -138,8 +138,8 @@ def test_ayanamsa_switch_changes_values():
     val2 = data2["meta"]["ayanamsa_deg"]
     assert not math.isclose(val1, val2, abs_tol=1e-3)
 
-    asc1 = data1["angles"]["asc_deg_sid"]
-    asc2 = data2["angles"]["asc_deg_sid"]
+    asc1 = data1["axes"]["asc_deg_sid"]
+    asc2 = data2["axes"]["asc_deg_sid"]
     assert not math.isclose(asc1, asc2, abs_tol=1e-3)
 
 


### PR DESCRIPTION
## Summary
- standardize on `axes` as the canonical label for Ascendant/Midheaven data
- expose house angle data under the `axes` key in `compute_houses`
- update house tests to expect the unified key

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b2b8841288832599db1f48a13a457a