### PR TITLE
Introduce canonical geometry and axis keys

### DIFF
--- a/astrocore/constants.py
+++ b/astrocore/constants.py
@@ -1,0 +1,50 @@
+"""Shared constant key names for astrocore."""
+from __future__ import annotations
+
+# Axis keys
+ASC_DEG_SID = "asc_deg_sid"
+MC_DEG_SID = "mc_deg_sid"
+ASC_DEG_TROP = "asc_deg_trop"
+MC_DEG_TROP = "mc_deg_trop"
+DESC_DEG_SID = "desc_deg_sid"
+IC_DEG_SID = "ic_deg_sid"
+
+AXES_KEYS = {
+    ASC_DEG_SID,
+    MC_DEG_SID,
+    ASC_DEG_TROP,
+    MC_DEG_TROP,
+    DESC_DEG_SID,
+    IC_DEG_SID,
+}
+
+# Geometry keys
+AYANAMSA_DEG = "ayanamsa_deg"
+EPSILON_DEG = "epsilon_deg"
+GST_HOURS = "gst_hours"
+LST_HOURS = "lst_hours"
+RAMC_DEG = "ramc_deg"
+
+GEOMETRY_KEYS = {
+    AYANAMSA_DEG,
+    EPSILON_DEG,
+    GST_HOURS,
+    LST_HOURS,
+    RAMC_DEG,
+}
+
+__all__ = [
+    "ASC_DEG_SID",
+    "MC_DEG_SID",
+    "ASC_DEG_TROP",
+    "MC_DEG_TROP",
+    "DESC_DEG_SID",
+    "IC_DEG_SID",
+    "AXES_KEYS",
+    "AYANAMSA_DEG",
+    "EPSILON_DEG",
+    "GST_HOURS",
+    "LST_HOURS",
+    "RAMC_DEG",
+    "GEOMETRY_KEYS",
+]

--- a/astrocore/eph/axes.py
+++ b/astrocore/eph/axes.py
@@ -3,6 +3,12 @@ from __future__ import annotations
 
 from typing import Dict
 
+from ..constants import (
+    ASC_DEG_SID,
+    MC_DEG_SID,
+    ASC_DEG_TROP,
+    MC_DEG_TROP,
+)
 from ..utils.angles import mod360
 from . import swiss
 
@@ -15,8 +21,8 @@ def compute_axes(jd_ut: float, ayanamsa_deg: float, lat: float, lon: float) -> D
     asc_sid = mod360(asc_trop - ayanamsa_deg)
     mc_sid = mod360(mc_trop - ayanamsa_deg)
     return {
-        "asc_deg_sid": asc_sid,
-        "mc_deg_sid": mc_sid,
-        "asc_deg_trop": asc_trop,
-        "mc_deg_trop": mc_trop,
+        ASC_DEG_SID: asc_sid,
+        MC_DEG_SID: mc_sid,
+        ASC_DEG_TROP: asc_trop,
+        MC_DEG_TROP: mc_trop,
     }

--- a/tests/test_houses.py
+++ b/tests/test_houses.py
@@ -9,6 +9,12 @@ from astrocore.houses import (
     compute_houses,
     _whole_sign_borders,
 )
+from astrocore.constants import (
+    ASC_DEG_SID,
+    MC_DEG_SID,
+    AYANAMSA_DEG,
+    RAMC_DEG,
+)
 
 
 
@@ -39,7 +45,7 @@ def test_whole_sign_structure():
 
     houses = data["houses"]
     angles = data["angles"]
-    assert "ramc_deg" in data["meta"]
+    assert RAMC_DEG in data["meta"]
 
     assert houses["type"] == "sign-based"
     borders = houses["borders_deg_sid"]
@@ -47,7 +53,7 @@ def test_whole_sign_structure():
     cusps = houses["cusps_deg_sid"]
     assert len(borders) == len(cusps) == 12
 
-    expected_start = math.floor((angles["asc_deg_sid"] - 1e-9) / 30.0) * 30.0
+    expected_start = math.floor((angles[ASC_DEG_SID] - 1e-9) / 30.0) * 30.0
     assert math.isclose(borders[0], expected_start, abs_tol=1e-6)
 
     # cusps are borders + 15° and widths are all 30°
@@ -75,8 +81,8 @@ def test_sripati_consistency():
     widths = houses["width_deg"]
     assert len(cusps) == len(borders) == len(widths) == 12
 
-    assert math.isclose(cusps[0], angles["asc_deg_sid"], abs_tol=1e-6)
-    assert math.isclose(cusps[9], angles["mc_deg_sid"], abs_tol=1e-6)
+    assert math.isclose(cusps[0], angles[ASC_DEG_SID], abs_tol=1e-6)
+    assert math.isclose(cusps[9], angles[MC_DEG_SID], abs_tol=1e-6)
 
     for i in range(12):
         mid = (cusps[i - 1] + ((cusps[i] - cusps[i - 1]) % 360.0) / 2.0) % 360.0
@@ -102,8 +108,8 @@ def test_placidus_contract():
     cusps = houses["cusps_deg_sid"]
     widths = houses["width_deg"]
 
-    assert math.isclose(borders[0], angles["asc_deg_sid"], abs_tol=1e-6)
-    assert math.isclose(borders[9], angles["mc_deg_sid"], abs_tol=1e-6)
+    assert math.isclose(borders[0], angles[ASC_DEG_SID], abs_tol=1e-6)
+    assert math.isclose(borders[9], angles[MC_DEG_SID], abs_tol=1e-6)
 
     for i in range(12):
         mid = (borders[i] + ((borders[(i + 1) % 12] - borders[i]) % 360.0) / 2.0) % 360.0
@@ -135,12 +141,12 @@ def test_ayanamsa_switch_changes_values():
     data1 = compute_houses(req1)
     data2 = compute_houses(req2)
 
-    val1 = data1["meta"]["ayanamsa_deg"]
-    val2 = data2["meta"]["ayanamsa_deg"]
+    val1 = data1["meta"][AYANAMSA_DEG]
+    val2 = data2["meta"][AYANAMSA_DEG]
     assert not math.isclose(val1, val2, abs_tol=1e-3)
 
-    asc1 = data1["angles"]["asc_deg_sid"]
-    asc2 = data2["angles"]["asc_deg_sid"]
+    asc1 = data1["angles"][ASC_DEG_SID]
+    asc2 = data2["angles"][ASC_DEG_SID]
     assert not math.isclose(asc1, asc2, abs_tol=1e-3)
 
 

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -1,0 +1,22 @@
+from astrocore import build_base_core
+from astrocore.constants import AXES_KEYS, GEOMETRY_KEYS
+
+
+def test_core_key_sets() -> None:
+    payload = {
+        "date": "1987-08-14",
+        "time": "08:30",
+        "tz_offset_hours": 4.0,
+        "latitude": 44.7153132,
+        "longitude": 42.9978716,
+        "settings": {
+            "sidereal": True,
+            "ayanamsa": "Lahiri",
+            "node_type": "MEAN",
+            "topocentric": False,
+        },
+    }
+    core = build_base_core(payload)
+
+    assert set(core["axes"].keys()) <= AXES_KEYS
+    assert set(core["geometry"].keys()) <= GEOMETRY_KEYS

--- a/tests/test_print_output.py
+++ b/tests/test_print_output.py
@@ -9,6 +9,14 @@ the printout provides the complete calculation result.
 import json
 
 from astrocore import build_base_core
+from astrocore.constants import (
+    ASC_DEG_SID,
+    MC_DEG_SID,
+    ASC_DEG_TROP,
+    MC_DEG_TROP,
+    AYANAMSA_DEG,
+    RAMC_DEG,
+)
 
 
 def test_print_core_output() -> None:
@@ -29,15 +37,15 @@ def test_print_core_output() -> None:
     print(json.dumps(core, indent=2, sort_keys=True))
 
     # Verify ayanamsa value is exposed with the new key
-    assert "ayanamsa_deg" in core["geometry"]
-    assert "ramc_deg" in core["geometry"]
+    assert AYANAMSA_DEG in core["geometry"]
+    assert RAMC_DEG in core["geometry"]
 
     # Ensure unified axis key names are present
     assert set(core["axes"].keys()) == {
-        "asc_deg_sid",
-        "mc_deg_sid",
-        "asc_deg_trop",
-        "mc_deg_trop",
+        ASC_DEG_SID,
+        MC_DEG_SID,
+        ASC_DEG_TROP,
+        MC_DEG_TROP,
     }
 
     # Extra formatted output: planetary positions within zodiac signs


### PR DESCRIPTION
## Summary
- add `astrocore.constants` with canonical axis and geometry keys
- replace string literals in axes and houses code with shared constants
- add regression test ensuring core output only uses known keys

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2b97f917c832588a1c49016f63775