### PR TITLE
Fix axes in house computation

### DIFF
--- a/astrocore/houses.py
+++ b/astrocore/houses.py
@@ -205,8 +205,8 @@ def compute_houses(req: HouseRequest) -> Dict[str, object]:
                 houses["width_deg"] = widths_from_borders(borders_sid)
 
 
-            angles[ASC_DEG_SID] = to_sidereal(asc_trop, ayanamsa_deg)
-            angles[MC_DEG_SID] = to_sidereal(mc_trop, ayanamsa_deg)
+            axes[ASC_DEG_SID] = to_sidereal(asc_trop, ayanamsa_deg)
+            axes[MC_DEG_SID] = to_sidereal(mc_trop, ayanamsa_deg)
 
         except Exception:
             backend = "native"
@@ -218,8 +218,8 @@ def compute_houses(req: HouseRequest) -> Dict[str, object]:
 
         asc_sid = to_sidereal(ang[ASC_DEG_TROP], ayanamsa_deg)
         mc_sid = to_sidereal(ang[MC_DEG_TROP], ayanamsa_deg)
-        angles[ASC_DEG_SID] = asc_sid
-        angles[MC_DEG_SID] = mc_sid
+        axes[ASC_DEG_SID] = asc_sid
+        axes[MC_DEG_SID] = mc_sid
 
 
         if req.house_system == "whole-sign":
@@ -244,8 +244,8 @@ def compute_houses(req: HouseRequest) -> Dict[str, object]:
                     houses["width_deg"] = widths_from_borders(borders)
 
 
-    angles[DESC_DEG_SID] = mod360(angles[ASC_DEG_SID] + 180.0)
-    angles[IC_DEG_SID] = mod360(angles[MC_DEG_SID] + 180.0)
+    axes[DESC_DEG_SID] = mod360(axes[ASC_DEG_SID] + 180.0)
+    axes[IC_DEG_SID] = mod360(axes[MC_DEG_SID] + 180.0)
 
 
     meta = {

--- a/tests/test_houses.py
+++ b/tests/test_houses.py
@@ -45,7 +45,7 @@ def test_whole_sign_structure():
 
     houses = data["houses"]
 
-    angles = data["angles"]
+    axes = data["axes"]
     assert RAMC_DEG in data["meta"]
 
 
@@ -56,7 +56,7 @@ def test_whole_sign_structure():
     assert len(borders) == len(cusps) == 12
 
 
-    expected_start = math.floor((angles[ASC_DEG_SID] - 1e-9) / 30.0) * 30.0
+    expected_start = math.floor((axes[ASC_DEG_SID] - 1e-9) / 30.0) * 30.0
 
     assert math.isclose(borders[0], expected_start, abs_tol=1e-6)
 
@@ -86,8 +86,8 @@ def test_sripati_consistency():
     assert len(cusps) == len(borders) == len(widths) == 12
 
 
-    assert math.isclose(cusps[0], angles[ASC_DEG_SID], abs_tol=1e-6)
-    assert math.isclose(cusps[9], angles[MC_DEG_SID], abs_tol=1e-6)
+    assert math.isclose(cusps[0], axes[ASC_DEG_SID], abs_tol=1e-6)
+    assert math.isclose(cusps[9], axes[MC_DEG_SID], abs_tol=1e-6)
 
 
     for i in range(12):
@@ -115,8 +115,8 @@ def test_placidus_contract():
     widths = houses["width_deg"]
 
 
-    assert math.isclose(borders[0], angles[ASC_DEG_SID], abs_tol=1e-6)
-    assert math.isclose(borders[9], angles[MC_DEG_SID], abs_tol=1e-6)
+    assert math.isclose(borders[0], axes[ASC_DEG_SID], abs_tol=1e-6)
+    assert math.isclose(borders[9], axes[MC_DEG_SID], abs_tol=1e-6)
 
 
     for i in range(12):
@@ -154,8 +154,8 @@ def test_ayanamsa_switch_changes_values():
     assert not math.isclose(val1, val2, abs_tol=1e-3)
 
 
-    asc1 = data1["angles"][ASC_DEG_SID]
-    asc2 = data2["angles"][ASC_DEG_SID]
+    asc1 = data1["axes"][ASC_DEG_SID]
+    asc2 = data2["axes"][ASC_DEG_SID]
 
     assert not math.isclose(asc1, asc2, abs_tol=1e-3)
 


### PR DESCRIPTION
## Summary
- populate `axes` in house computations by replacing stale `angles` refs
- update house tests to reference `axes`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b2c0dfad3c8325afc6d2c0bc278d24