### PR TITLE
Standardize latitude/longitude naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,5 @@
 ## Unreleased
 - Renamed geometry key `armc_deg` to `ramc_deg` and removed the `lst_deg`
   metadata alias from `compute_houses`.
+- Standardized location fields to `latitude_deg` and `longitude_deg` across
+  public APIs and documentation.

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ payload = {
     "date": "2024-01-01",
     "time": "12:00",
     "tz_offset_hours": 1.0,
-    "latitude": 52.37,
-    "longitude": 4.90,
+    "latitude_deg": 52.37,
+    "longitude_deg": 4.90,
     "settings": {
         "sidereal": True,
         "ayanamsa": "Lahiri",

--- a/astrocore/types.py
+++ b/astrocore/types.py
@@ -15,8 +15,8 @@ class BaseInput(TypedDict):
     date: str
     time: str
     tz_offset_hours: float
-    latitude: float
-    longitude: float
+    latitude_deg: float
+    longitude_deg: float
     settings: CoreSettings
 
 

--- a/tests/test_houses.py
+++ b/tests/test_houses.py
@@ -20,8 +20,8 @@ from astrocore.constants import (
 
 REQ_ARGS = dict(
     jd_ut=2447021.6875,
-    geo_lat_deg=44.7153132,
-    geo_lon_deg=42.9978716,
+    latitude_deg=44.7153132,
+    longitude_deg=42.9978716,
 
 )
 
@@ -131,8 +131,8 @@ def test_placidus_contract():
 def test_placidus_fallback_high_latitude():
     req = HouseRequest(
         jd_ut=2447013.856,
-        geo_lat_deg=70.0,
-        geo_lon_deg=0.0,
+        latitude_deg=70.0,
+        longitude_deg=0.0,
         ayanamsa="Lahiri",
         house_system="placidus",
     )

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -7,8 +7,8 @@ def test_core_key_sets() -> None:
         "date": "1987-08-14",
         "time": "08:30",
         "tz_offset_hours": 4.0,
-        "latitude": 44.7153132,
-        "longitude": 42.9978716,
+        "latitude_deg": 44.7153132,
+        "longitude_deg": 42.9978716,
         "settings": {
             "sidereal": True,
             "ayanamsa": "Lahiri",

--- a/tests/test_print_output.py
+++ b/tests/test_print_output.py
@@ -24,8 +24,8 @@ def test_print_core_output() -> None:
         "date": "1987-08-14",
         "time": "08:30",
         "tz_offset_hours": 4.0,
-        "latitude": 44.7153132,
-        "longitude": 42.9978716,
+        "latitude_deg": 44.7153132,
+        "longitude_deg": 42.9978716,
         "settings": {
             "sidereal": True,
             "ayanamsa": "Lahiri",


### PR DESCRIPTION
## Summary
- Use `latitude_deg` and `longitude_deg` consistently across core APIs
- Update `HouseRequest`, `BaseInput`, and geometry builder to new keys
- Refresh docs and tests to reflect canonical location fields

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2c2f2fe808325bb04c7566894ff32