### PR TITLE
Add DMS angle conversion utilities

### DIFF
--- a/astrocore/utils/__init__.py
+++ b/astrocore/utils/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .dms import dec_to_dms360, format_dms360
+
+__all__ = ["dec_to_dms360", "format_dms360"]

--- a/astrocore/utils/dms.py
+++ b/astrocore/utils/dms.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+import math
+
+__all__ = ["dec_to_dms360", "format_dms360"]
+
+def _normalize360(x: float) -> float:
+    if math.isnan(x) or math.isinf(x):
+        raise ValueError("Angle must be finite.")
+    x = math.fmod(x, 360.0)
+    if x < 0:
+        x += 360.0
+    return x
+
+def dec_to_dms360(value_deg: float, *, sec_precision: int = 3) -> tuple[int, int, float]:
+    """Convert decimal degrees to DMS for angles on [0,360)."""
+    x = _normalize360(value_deg)
+    total_sec = x * 3600.0
+    # round half up (avoid banker's rounding)
+    q = 10 ** sec_precision
+    sec_rounded = math.floor(total_sec * q + 0.5) / q
+
+    deg = int(sec_rounded // 3600)
+    rem = sec_rounded - deg * 3600
+    minute = int(rem // 60)
+    second = rem - minute * 60
+
+    # cascade checks
+    if second >= 60 - 10 ** (-sec_precision):
+        second = 0.0
+        minute += 1
+    if minute >= 60:
+        minute = 0
+        deg += 1
+    if deg >= 360:
+        deg = 0
+
+    return deg, minute, round(second, sec_precision)
+
+def format_dms360(value_deg: float, *, sec_precision: int = 3,
+                  zero_pad: bool = True, symbols: tuple[str, str, str] = ("°", "′", "″")) -> str:
+    d, m, s = dec_to_dms360(value_deg, sec_precision=sec_precision)
+    deg_sym, min_sym, sec_sym = symbols
+    if zero_pad:
+        m_str = f"{m:02d}"
+        s_fmt = f"{{:0{2 + (1 + sec_precision if sec_precision > 0 else 0)}.{sec_precision}f}}"
+        s_str = s_fmt.format(s) if sec_precision > 0 else f"{int(round(s)):02d}"
+    else:
+        m_str = str(m)
+        s_str = f"{s:.{sec_precision}f}" if sec_precision > 0 else str(int(round(s)))
+    return f"{d}{deg_sym} {m_str}{min_sym} {s_str}{sec_sym}"

--- a/tests/test_print_output.py
+++ b/tests/test_print_output.py
@@ -48,20 +48,18 @@ def test_print_core_output() -> None:
         MC_DEG_TROP,
     }
 
-    # Extra formatted output: planetary positions within zodiac signs
-    from derived.signs import lon_to_sign_deg
+    # Extra formatted output: planetary positions in DMS
+    from astrocore.utils import format_dms360
 
     print("\nFormatted positions:")
     for body_name, data in core.get("planets", {}).items():
         trop_str = "-"
         if "lon_tropical_deg" in data:
-            sign, deg = lon_to_sign_deg(data["lon_tropical_deg"])
-            trop_str = f"{deg:.2f}\u00b0 {sign}"
+            trop_str = format_dms360(data["lon_tropical_deg"])
 
         sid_str = "-"
         if "lon_sidereal_deg" in data:
-            sign_s, deg_s = lon_to_sign_deg(data["lon_sidereal_deg"])
-            sid_str = f"{deg_s:.2f}\u00b0 {sign_s}"
+            sid_str = format_dms360(data["lon_sidereal_deg"])
 
         print(f"{body_name:9s} trop={trop_str} sid={sid_str}")
 

--- a/tests/test_utils_dms.py
+++ b/tests/test_utils_dms.py
@@ -1,0 +1,40 @@
+import math
+
+import pytest
+
+from astrocore.utils.dms import dec_to_dms360, format_dms360
+
+
+def test_basic_case():
+    angle = 143.0350530119635
+    deg, minute, sec = dec_to_dms360(angle)
+    assert deg == 143
+    assert minute == 2
+    assert sec == pytest.approx(6.191, abs=1e-12)
+    assert format_dms360(angle) == "143° 02′ 06.191″"
+    reconstructed = deg + minute / 60 + sec / 3600
+    assert reconstructed == pytest.approx(angle, abs=1e-6)
+
+
+@pytest.mark.parametrize(
+    "value,expected_str",
+    [
+        (0.0, "0° 00′ 00.000″"),
+        (359.9999996, "0° 00′ 00.000″"),
+        (360.0, "0° 00′ 00.000″"),
+        (-0.0001, "359° 59′ 59.640″"),
+        (720.5, "0° 30′ 00.000″"),
+    ],
+)
+def test_edge_cases(value, expected_str):
+    deg, minute, sec = dec_to_dms360(value)
+    assert 0 <= deg < 360
+    assert 0 <= minute < 60
+    assert 0 <= sec < 60
+    assert format_dms360(value) == expected_str
+
+
+@pytest.mark.parametrize("value", [math.nan, math.inf, -math.inf])
+def test_invalid_values(value):
+    with pytest.raises(ValueError):
+        dec_to_dms360(value)


### PR DESCRIPTION
## Summary
- add decimal degree to DMS conversion with rounding and normalization
- format DMS strings with zero-padding and precision options
- cover edge cases like wrap-around and invalid values
- show DMS-formatted planetary positions in print test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b36227168083258ab2b9db793604a4