### PR TITLE
Add derived core builder with aspects and signs

### DIFF
--- a/derived/__init__.py
+++ b/derived/__init__.py
@@ -1,1 +1,5 @@
-"""Derived calculations placeholder."""
+"""Derived calculations."""
+
+from .core import build_derived_core
+
+__all__ = ["build_derived_core"]

--- a/derived/core.py
+++ b/derived/core.py
@@ -1,0 +1,61 @@
+"""Derived core calculations."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from astrocore import build_base_core
+from astrocore.types import BaseInput, CoreOutput
+
+from .signs import lon_to_sign_deg
+
+
+def compute_aspects(core: CoreOutput) -> Dict[str, Any]:
+    """Compute simplistic aspects between planets.
+
+    The implementation is intentionally lightweight: for every unique pair of
+    planets it computes the absolute difference in longitude and folds values
+    greater than 180 degrees. The house system is also passed through so the
+    function touches both planetary and house data from the core payload.
+    """
+    planets = core.get("planets", {})
+    houses = core.get("houses", {})
+    names = list(planets.keys())
+    aspects: Dict[str, float] = {}
+    for i, p1 in enumerate(names):
+        lon1 = planets[p1].get("lon_deg") or planets[p1].get("lon_sidereal_deg") or planets[p1].get("lon_tropical_deg")
+        if lon1 is None:
+            continue
+        for p2 in names[i + 1 :]:
+            lon2 = planets[p2].get("lon_deg") or planets[p2].get("lon_sidereal_deg") or planets[p2].get("lon_tropical_deg")
+            if lon2 is None:
+                continue
+            diff = abs(lon1 - lon2) % 360.0
+            if diff > 180.0:
+                diff = 360.0 - diff
+            aspects[f"{p1}-{p2}"] = diff
+    return {"pairs": aspects, "house_system": houses.get("house_system")}
+
+
+def compute_signs(core: CoreOutput) -> Dict[str, str]:
+    """Map each planet to its zodiac sign."""
+    result: Dict[str, str] = {}
+    for name, data in core.get("planets", {}).items():
+        lon = data.get("lon_sidereal_deg") or data.get("lon_tropical_deg") or data.get("lon_deg")
+        if lon is None:
+            continue
+        sign, _ = lon_to_sign_deg(lon)
+        result[name] = sign
+    return result
+
+
+def build_derived_core(payload: BaseInput) -> Dict[str, Any]:
+    """Build combined core data with derived calculations."""
+    core = build_base_core(payload)
+    derived = {
+        "aspects": compute_aspects(core),
+        "signs": compute_signs(core),
+    }
+    return {**core, **derived}
+
+
+__all__ = ["build_derived_core", "compute_aspects", "compute_signs"]

--- a/tests/test_derived_core.py
+++ b/tests/test_derived_core.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Dict
+from unittest.mock import patch
+
+from derived.core import build_derived_core
+
+
+def sample_payload() -> Dict[str, object]:
+    return {
+        "date": "2000-01-01",
+        "time": "12:00",
+        "tz_offset_hours": 0.0,
+        "latitude_deg": 0.0,
+        "longitude_deg": 0.0,
+    }
+
+
+def test_build_derived_core_calls_base_core_once() -> None:
+    payload = sample_payload()
+    core = {"planets": {}, "houses": {}}
+    with (
+        patch("derived.core.build_base_core", return_value=core) as mock_base,
+        patch("derived.core.compute_aspects", return_value={}),
+        patch("derived.core.compute_signs", return_value={}),
+    ):
+        build_derived_core(payload)
+    mock_base.assert_called_once_with(payload)
+
+
+def test_build_derived_core_passes_core_to_helpers() -> None:
+    payload = sample_payload()
+    core = {"planets": {"Sun": {"lon_deg": 50.0}}, "houses": {"house_system": "X"}}
+    with (
+        patch("derived.core.build_base_core", return_value=core),
+        patch("derived.core.compute_aspects") as mock_aspects,
+        patch("derived.core.compute_signs") as mock_signs,
+    ):
+        build_derived_core(payload)
+    mock_aspects.assert_called_once_with(core)
+    mock_signs.assert_called_once_with(core)


### PR DESCRIPTION
## Summary
- implement `build_derived_core` assembling base and derived calculations
- add helper functions `compute_aspects` and `compute_signs`
- expose derived builder via package init and add unit tests

## Testing
- `pre-commit run --files derived/core.py derived/__init__.py tests/test_derived_core.py`
- `pytest -q` *(fails: IndentationError in tests/test_print_output.py)*
- `pytest tests/test_derived_core.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5c2273958832595c6c5952e5d1f43